### PR TITLE
Check CKAN version before using JSON validator

### DIFF
--- a/ckanext/translate/logic/schema.py
+++ b/ckanext/translate/logic/schema.py
@@ -3,9 +3,14 @@ import string
 
 def translate():
     not_empty = tk.get_validator("not_empty")
-    json_object = tk.get_validator("json_object")
+    input_validators = [not_empty]
+
+    if tk.check_ckan_version(min_version='2.8.5'):
+        json_object = tk.get_validator("json_object")
+        input_validators = [not_empty, json_object]
+
     return {
-        "input": [not_empty, json_object],
+        "input": input_validators,
         "from": [not_empty],
         "to": [not_empty],
     }


### PR DESCRIPTION
The `json_object` validator doesn't exist in CKAN versions below 2.8.5. This adds a check to only use the validator if the CKAN version is 2.8.5+.